### PR TITLE
Fix display of headings on the posts list

### DIFF
--- a/site/themes/pyconth/assets/css/custom.css
+++ b/site/themes/pyconth/assets/css/custom.css
@@ -3,6 +3,6 @@
     border-color: #511c39;
 }
 
-body.index header {
+body.frontpage header {
     display: none;
 }

--- a/site/themes/pyconth/templates/base.tmpl
+++ b/site/themes/pyconth/templates/base.tmpl
@@ -8,7 +8,7 @@ ${base.html_headstart()}
 </%block>
 ${template_hooks['extra_head']()}
 </head> 
-<body class="${' '.join(pagekind)} ${' '.join(permalink.strip('/'+lang).split('/')) if permalink.strip('/'+lang) else 'index'}  lang_${lang} lang_${'rtl' if is_rtl else 'ltr'}">
+<body class="${' '.join(pagekind)} ${' '.join(permalink.strip('/'+lang).split('/')) if permalink.strip('/'+lang) else 'frontpage'}  lang_${lang} lang_${'rtl' if is_rtl else 'ltr'}">
 <a href="#content" class="sr-only sr-only-focusable">${messages("Skip to main content")}</a>
 
 <!-- Menubar -->


### PR DESCRIPTION
'index' could come from both `pagekind` and from the 'else' in the `permalink` clause